### PR TITLE
Fix Issue #21: Isochronous Transfer buffer truncation

### DIFF
--- a/USBPcapDriver/USBPcapURB.c
+++ b/USBPcapDriver/USBPcapURB.c
@@ -221,9 +221,11 @@ USBPcapAnalyzeControlTransfer(struct _URB_CONTROL_TRANSFER* transfer,
     }
 
     /* Add Data stage to log */
-    if ((transfer->TransferBufferLength != 0) &&
-        (((post == FALSE) && ((transfer->TransferFlags & USBD_TRANSFER_DIRECTION_IN) == USBD_TRANSFER_DIRECTION_OUT)) ||
-         ((post == TRUE) && ((transfer->TransferFlags & USBD_TRANSFER_DIRECTION_IN) == USBD_TRANSFER_DIRECTION_IN))))
+    if (transfer->TransferBufferLength != 0 &&
+        ((post == FALSE &&
+        (transfer->TransferFlags & USBD_TRANSFER_DIRECTION_OUT)) ||
+        ((post == TRUE) &&
+        !(transfer->TransferFlags & USBD_TRANSFER_DIRECTION_OUT))))
     {
         PVOID  transferBuffer;
 

--- a/USBPcapDriver/USBPcapURB.c
+++ b/USBPcapDriver/USBPcapURB.c
@@ -681,18 +681,17 @@ VOID USBPcapAnalyzeURB(PIRP pIrp, PURB pUrb, BOOLEAN post,
                     /* Read from device, return from controller */
                     if (transfer->TransferBuffer)
                     {
+                        /* return packet buffers only if data has been transferred */
                         if (transfer->TransferBufferLength > 0)
                         {
-                            transferLength =
-                                transfer->IsoPacket[transfer->NumberOfPackets - 1].Offset +
-                                transfer->IsoPacket[transfer->NumberOfPackets - 1].Length;
-
-                            /* In practice, the array is always sorted in order of offsets.
-                               However, this is not guaranteed, so we scan for the maximum. */
                             for (i = 0; i < transfer->NumberOfPackets; i++)
                             {
-                                if (transferLength < transfer->IsoPacket[i].Offset + transfer->IsoPacket[i].Length)
+                                /* capture only packet buffers that contain data to minimize capture size */
+                                if ((transfer->IsoPacket[i].Length > 0) &&
+                                    (transferLength < transfer->IsoPacket[i].Offset + transfer->IsoPacket[i].Length))
+                                {
                                     transferLength = transfer->IsoPacket[i].Offset + transfer->IsoPacket[i].Length;
+                                }
                             }
                         }
                     }

--- a/USBPcapDriver/USBPcapURB.c
+++ b/USBPcapDriver/USBPcapURB.c
@@ -681,16 +681,19 @@ VOID USBPcapAnalyzeURB(PIRP pIrp, PURB pUrb, BOOLEAN post,
                     /* Read from device, return from controller */
                     if (transfer->TransferBuffer)
                     {
-                        transferLength =
-                            transfer->IsoPacket[transfer->NumberOfPackets - 1].Offset +
-                            transfer->IsoPacket[transfer->NumberOfPackets - 1].Length;
-
-                        /* In practice, the array is always sorted in order of offsets.
-                           However, this is not guaranteed, so we scan for the maximum. */
-                        for (i = 0; i < transfer->NumberOfPackets; i++)
+                        if (transfer->TransferBufferLength > 0)
                         {
-                            if (transferLength < transfer->IsoPacket[i].Offset + transfer->IsoPacket[i].Length)
-                                transferLength = transfer->IsoPacket[i].Offset + transfer->IsoPacket[i].Length;
+                            transferLength =
+                                transfer->IsoPacket[transfer->NumberOfPackets - 1].Offset +
+                                transfer->IsoPacket[transfer->NumberOfPackets - 1].Length;
+
+                            /* In practice, the array is always sorted in order of offsets.
+                               However, this is not guaranteed, so we scan for the maximum. */
+                            for (i = 0; i < transfer->NumberOfPackets; i++)
+                            {
+                                if (transferLength < transfer->IsoPacket[i].Offset + transfer->IsoPacket[i].Length)
+                                    transferLength = transfer->IsoPacket[i].Offset + transfer->IsoPacket[i].Length;
+                            }
                         }
                     }
                     else if (transfer->TransferBufferMDL)


### PR DESCRIPTION
This pull request fixes Isochronous Transfer buffer truncation (Issue #21).
Returns isoch packet buffers only if data has been transferred.
Captures only packet buffers that contain data to minimize capture size.