### PR TITLE
Fixed issue with random endpoint selection after series of sets for interface/configuration

### DIFF
--- a/USBPcapDriver/USBPcapTables.c
+++ b/USBPcapDriver/USBPcapTables.c
@@ -54,13 +54,12 @@ VOID USBPcapAddEndpointInfo(IN PRTL_GENERIC_TABLE table,
                                  sizeof(USBPCAP_INTERNAL_ENDPOINT_INFO),
                                  &new);
 
-    if (new == FALSE)
+    if ((new == FALSE) && (pInfo != NULL))
     {
         DkDbgStr("Element already exists in table, updating entry");
         pInfo->info.type            = pipeInfo->PipeType;
         pInfo->info.endpointAddress = pipeInfo->EndpointAddress;
         pInfo->info.deviceAddress   = deviceAddress;
-        DkDbgStr("Replace Done!");
     }
 }
 

--- a/USBPcapDriver/USBPcapTables.c
+++ b/USBPcapDriver/USBPcapTables.c
@@ -54,8 +54,11 @@ VOID USBPcapAddEndpointInfo(IN PRTL_GENERIC_TABLE table,
                                  &new);
 
     if (new == FALSE)
-    {
-        DkDbgStr("Element already exists in table");
+    {        
+		DkDbgStr("Element already exists in table. Lets replace it!");
+		USBPcapRemoveEndpointInfo(table, pipeInfo->PipeHandle);
+		USBPcapAddEndpointInfo(table, pipeInfo, deviceAddress);
+		DkDbgStr("Replace Done!");
     }
 }
 

--- a/USBPcapDriver/USBPcapTables.c
+++ b/USBPcapDriver/USBPcapTables.c
@@ -56,7 +56,7 @@ VOID USBPcapAddEndpointInfo(IN PRTL_GENERIC_TABLE table,
 
     if (new == FALSE)
     {
-        DkDbgStr("Element already exists in table. Lets replace elements data!");
+        DkDbgStr("Element already exists in table, updating entry");
         pInfo->info.type            = pipeInfo->PipeType;
         pInfo->info.endpointAddress = pipeInfo->EndpointAddress;
         pInfo->info.deviceAddress   = deviceAddress;

--- a/USBPcapDriver/USBPcapTables.c
+++ b/USBPcapDriver/USBPcapTables.c
@@ -42,23 +42,25 @@ VOID USBPcapAddEndpointInfo(IN PRTL_GENERIC_TABLE table,
 {
     USBPCAP_INTERNAL_ENDPOINT_INFO  info;
     BOOLEAN                         new;
+    PUSBPCAP_INTERNAL_ENDPOINT_INFO pInfo;
 
     info.info.handle          = pipeInfo->PipeHandle;
     info.info.type            = pipeInfo->PipeType;
     info.info.endpointAddress = pipeInfo->EndpointAddress;
     info.info.deviceAddress   = deviceAddress;
 
-    RtlInsertElementGenericTable(table,
+    pInfo = RtlInsertElementGenericTable(table,
                                  (PVOID)&info,
                                  sizeof(USBPCAP_INTERNAL_ENDPOINT_INFO),
                                  &new);
 
     if (new == FALSE)
-    {        
-		DkDbgStr("Element already exists in table. Lets replace it!");
-		USBPcapRemoveEndpointInfo(table, pipeInfo->PipeHandle);
-		USBPcapAddEndpointInfo(table, pipeInfo, deviceAddress);
-		DkDbgStr("Replace Done!");
+    {
+        DkDbgStr("Element already exists in table. Lets replace elements data!");
+        pInfo->info.type            = pipeInfo->PipeType;
+        pInfo->info.endpointAddress = pipeInfo->EndpointAddress;
+        pInfo->info.deviceAddress   = deviceAddress;
+        DkDbgStr("Replace Done!");
     }
 }
 


### PR DESCRIPTION
… same pipe buffers for different endpoints. Adding code that will replace new USBPCAP_INTERNAL_ENDPOINT_INFO with old one.