### PR TITLE
Critical fix: buffer size was not updated on kernel buffer reallocation

### DIFF
--- a/USBPcapDriver/USBPcapBuffer.c
+++ b/USBPcapDriver/USBPcapBuffer.c
@@ -297,6 +297,7 @@ NTSTATUS USBPcapSetUpBuffer(PUSBPCAP_ROOTHUB_DATA pData,
             /* Free the old buffer */
             ExFreePool(pData->buffer);
             pData->buffer = buffer;
+            pData->bufferSize = bytes;
             pData->readOffset = 0;
             pData->writeOffset = allocated;
         }


### PR DESCRIPTION
This leads to kernel memory corruption and likely BSODs on decreasing the original buffer size.
